### PR TITLE
Fix custom user name

### DIFF
--- a/script/vagrant.sh
+++ b/script/vagrant.sh
@@ -2,7 +2,7 @@
 
 echo '==> Configuring settings for vagrant'
 
-SSH_USER=${SSH_USER:-vagrant}
+SSH_USER=${SSH_USERNAME:-vagrant}
 SSH_USER_HOME=${SSH_USER_HOME:-/home/${SSH_USER}}
 VAGRANT_INSECURE_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
 


### PR DESCRIPTION
Fix a typo. The [real variable name](https://github.com/boxcutter/centos/blob/45b25140510d4e30033c01a39d8f04c0debadba4/centos71.json#L122) is `SSH_USERNAME`.

I’ve tested it with a custom user name. Works for me.
