### PR TITLE
Remove gcc dependencies as well

### DIFF
--- a/script/vmtool.sh
+++ b/script/vmtool.sh
@@ -106,4 +106,4 @@ if [[ $PACKER_BUILDER_TYPE =~ parallels ]]; then
 fi
 
 echo "==> Removing packages needed for building guest tools"
-yum -y remove gcc cpp kernel-devel kernel-headers perl
+yum -y remove gcc cpp libmpc mpfr kernel-devel kernel-headers perl


### PR DESCRIPTION
The `libmpc` and `mpfr` are dependencies of `gcc`. It’s pretty safe to remove these after gcc.
