### PR TITLE
Stringify `install_vagrant_key' variable

### DIFF
--- a/centos510-i386.json
+++ b/centos510-i386.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "bb4e61210e1c0389fdf55c59bd2dd7bc957dd400",
     "iso_name": "CentOS-5.10-i386-bin-DVD-1of2.iso",
     "iso_path": "iso",

--- a/centos510.json
+++ b/centos510.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "d8403b3fe4972eda3e147ee76d682a4a3beae1e1",
     "iso_name": "CentOS-5.10-x86_64-bin-DVD-1of2.iso",
     "iso_path": "iso",

--- a/centos511-i386.json
+++ b/centos511-i386.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "ec3a89b4edc8e391d13c1ecce4e6ce3917719e39",
     "iso_name": "CentOS-5.11-i386-bin-DVD-1of2.iso",
     "iso_path": "iso",

--- a/centos511.json
+++ b/centos511.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "ebd77f2fdfac8da04f31c508905cf52aa62937cc",
     "iso_name": "CentOS-5.11-x86_64-bin-DVD-1of2.iso",
     "iso_path": "iso",

--- a/centos64-desktop.json
+++ b/centos64-desktop.json
@@ -147,7 +147,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "8672dc087f1b0eda60b9efaa41b82f034f185e24",
     "iso_name": "CentOS-6.4-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos64-i386.json
+++ b/centos64-i386.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "4bd3a1de6f6dfcd7a2199487abf5a9304d696cae",
     "iso_name": "CentOS-6.4-i386-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos64.json
+++ b/centos64.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "8672dc087f1b0eda60b9efaa41b82f034f185e24",
     "iso_name": "CentOS-6.4-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos65-desktop.json
+++ b/centos65-desktop.json
@@ -147,7 +147,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "32c7695b97f7dcd1f59a77a71f64f2957dddf738",
     "iso_name": "CentOS-6.5-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos65-docker.json
+++ b/centos65-docker.json
@@ -146,7 +146,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "32c7695b97f7dcd1f59a77a71f64f2957dddf738",
     "iso_name": "CentOS-6.5-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos65-i386.json
+++ b/centos65-i386.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "67ea68068ae53d1f23431072ec0288b3e1abfe4d",
     "iso_name": "CentOS-6.5-i386-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos65.json
+++ b/centos65.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "32c7695b97f7dcd1f59a77a71f64f2957dddf738",
     "iso_name": "CentOS-6.5-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos66-desktop.json
+++ b/centos66-desktop.json
@@ -147,7 +147,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
     "iso_name": "CentOS-6.6-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos66-docker.json
+++ b/centos66-docker.json
@@ -146,7 +146,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
     "iso_name": "CentOS-6.6-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos66-i386.json
+++ b/centos66-i386.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "d16aa4a8e6f71fb01fcc26d8ae0e3443ed514c8e",
     "iso_name": "CentOS-6.6-i386-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos66.json
+++ b/centos66.json
@@ -145,7 +145,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
     "iso_name": "CentOS-6.6-x86_64-bin-DVD1.iso",
     "iso_path": "iso",

--- a/centos70-desktop.json
+++ b/centos70-desktop.json
@@ -150,7 +150,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "154ba47b7a37e52e0100310c3aeb8f9d9daf4806",
     "iso_name": "CentOS-7.0-1406-x86_64-DVD.iso",
     "iso_path": "iso",

--- a/centos70-docker.json
+++ b/centos70-docker.json
@@ -149,7 +149,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "154ba47b7a37e52e0100310c3aeb8f9d9daf4806",
     "iso_name": "CentOS-7.0-1406-x86_64-DVD.iso",
     "iso_path": "iso",

--- a/centos70.json
+++ b/centos70.json
@@ -148,7 +148,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "154ba47b7a37e52e0100310c3aeb8f9d9daf4806",
     "iso_name": "CentOS-7.0-1406-x86_64-DVD.iso",
     "iso_path": "iso",

--- a/centos71-desktop.json
+++ b/centos71-desktop.json
@@ -150,7 +150,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "1795184136b8bdddabe50453cc2cc2d46f0f7c5e",
     "iso_name": "CentOS-7-x86_64-DVD-1503-01.iso",
     "iso_path": "iso",

--- a/centos71-docker.json
+++ b/centos71-docker.json
@@ -149,7 +149,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "1795184136b8bdddabe50453cc2cc2d46f0f7c5e",
     "iso_name": "CentOS-7-x86_64-DVD-1503-01.iso",
     "iso_path": "iso",

--- a/centos71.json
+++ b/centos71.json
@@ -148,7 +148,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "install_vagrant_key": true,
+    "install_vagrant_key": "true",
     "iso_checksum": "1795184136b8bdddabe50453cc2cc2d46f0f7c5e",
     "iso_name": "CentOS-7-x86_64-DVD-1503-01.iso",
     "iso_path": "iso",


### PR DESCRIPTION
Packer v0.8.0 refuses to accept bool values of `install_vagrant_key':

| Failed to parse template: 1 error(s) occurred:
|
| \* variable install_vagrant_key: '' expected type 'string', got unconvertible type 'bool'

Closes #14.
