### PR TITLE
selinux python bindings. closes #18

### DIFF
--- a/http/ks5.cfg
+++ b/http/ks5.cfg
@@ -57,6 +57,7 @@ dhclient
 sudo
 yum
 nfs-utils
+libselinux-python
 -fprintd-pam
 -intltool
 -avahi

--- a/http/ks6-desktop.cfg
+++ b/http/ks6-desktop.cfg
@@ -69,6 +69,8 @@ make
 perl
 curl
 wget
+# Other stuff
+libselinux-python
 
 %post
 # configure vagrant user in sudoers

--- a/http/ks6.cfg
+++ b/http/ks6.cfg
@@ -53,6 +53,7 @@ wget
 # Other stuff
 sudo
 nfs-utils
+libselinux-python
 -fprintd-pam
 -intltool
 # Workaround for selinux

--- a/http/ks7-desktop.cfg
+++ b/http/ks7-desktop.cfg
@@ -73,6 +73,7 @@ git
 # Other stuff
 sudo
 nfs-utils
+libselinux-python
 %end
 
 %post

--- a/http/ks7.cfg
+++ b/http/ks7.cfg
@@ -58,6 +58,7 @@ git
 # Other stuff
 sudo
 nfs-utils
+libselinux-python
 -fprintd-pam
 -intltool
 


### PR DESCRIPTION
Allows Ansible to manage images running selinux 'Permissive' (changed in 1.0.17).
