### PR TITLE
Bugfix: ISO url for CentOS 6.6 is no longer valid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ packer_cache/
 output-*
 *.box
 *.tar.gz
-iso
+iso/*
 crash.log
 tmp
 .vagrant/
@@ -10,5 +10,5 @@ tmp
 Makefile.local
 box/
 .tmpatlas/
-
 .DS_Store
+.idea

--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Rickard von Essen <rickard.von.essen@gmail.com>
 Ross Smith II <ross@smithii.com>
 Trevor Dearham <Trevor.Dearham@gmail.com>
 Victor Volle <v.volle@computer.org>
+Jd Daniel <dodomeki@gmail.com>

--- a/centos66-desktop.json
+++ b/centos66-desktop.json
@@ -151,7 +151,7 @@
     "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
     "iso_name": "CentOS-6.6-x86_64-bin-DVD1.iso",
     "iso_path": "iso",
-    "iso_url": "http://mirrors.kernel.org/centos/6.6/isos/x86_64/CentOS-6.6-x86_64-bin-DVD1.iso",
+    "iso_url": "http://archive.kernel.org/centos-vault/6.6/isos/x86_64/CentOS-6.6-x86_64-bin-DVD1.iso",
     "no_proxy": "{{env `no_proxy`}}",
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "ssh_password": "vagrant",

--- a/centos66-docker.json
+++ b/centos66-docker.json
@@ -150,7 +150,7 @@
     "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
     "iso_name": "CentOS-6.6-x86_64-bin-DVD1.iso",
     "iso_path": "iso",
-    "iso_url": "http://mirrors.kernel.org/centos/6.6/isos/x86_64/CentOS-6.6-x86_64-bin-DVD1.iso",
+    "iso_url": "http://archive.kernel.org/centos-vault/6.6/isos/x86_64/CentOS-6.6-x86_64-bin-DVD1.iso",
     "no_proxy": "{{env `no_proxy`}}",
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "ssh_password": "vagrant",

--- a/centos66-i386.json
+++ b/centos66-i386.json
@@ -149,7 +149,7 @@
     "iso_checksum": "d16aa4a8e6f71fb01fcc26d8ae0e3443ed514c8e",
     "iso_name": "CentOS-6.6-i386-bin-DVD1.iso",
     "iso_path": "iso",
-    "iso_url": "http://mirrors.kernel.org/centos/6.6/isos/i386/CentOS-6.6-i386-bin-DVD1.iso",
+    "iso_url": "http://archive.kernel.org/centos-vault/6.6/isos/i386/CentOS-6.6-i386-bin-DVD1.iso",
     "no_proxy": "{{env `no_proxy`}}",
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "ssh_password": "vagrant",

--- a/centos66.json
+++ b/centos66.json
@@ -149,7 +149,7 @@
     "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
     "iso_name": "CentOS-6.6-x86_64-bin-DVD1.iso",
     "iso_path": "iso",
-    "iso_url": "http://mirrors.kernel.org/centos/6.6/isos/x86_64/CentOS-6.6-x86_64-bin-DVD1.iso",
+    "iso_url": "http://archive.kernel.org/centos-vault/6.6/isos/x86_64/CentOS-6.6-x86_64-bin-DVD1.iso",
     "no_proxy": "{{env `no_proxy`}}",
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "ssh_password": "vagrant",

--- a/iso/.gitignore
+++ b/iso/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Adding in correct URL in order to obtain iso(s)
