### PR TITLE
use ssh_pty on centos7

### DIFF
--- a/centos70-desktop.json
+++ b/centos70-desktop.json
@@ -21,6 +21,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "centos70-desktop",
@@ -50,6 +51,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/centos70-docker.json
+++ b/centos70-docker.json
@@ -21,6 +21,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "centos70-docker",
@@ -50,6 +51,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/centos70.json
+++ b/centos70.json
@@ -21,6 +21,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "centos70",
@@ -50,6 +51,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/centos71-desktop.json
+++ b/centos71-desktop.json
@@ -21,6 +21,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "centos71-desktop",
@@ -50,6 +51,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/centos71-docker.json
+++ b/centos71-docker.json
@@ -21,6 +21,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "centos71-docker",
@@ -50,6 +51,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/centos71.json
+++ b/centos71.json
@@ -21,6 +21,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "centos71",
@@ -50,6 +51,7 @@
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
+      "ssh_pty": true,
       "type": "virtualbox-iso",
       "vboxmanage": [
         [


### PR DESCRIPTION
'make virtualbox/centos71-desktop' makes following error because CentOS7's sudo
require tty. So, use ssh_pty.

  ==> virtualbox-iso: Provisioning with shell script: script/fix-slow-dns.sh
      virtualbox-iso: sudo: sorry, you must have a tty to run sudo
  ==> virtualbox-iso: Unregistering and deleting virtual machine...
  ==> virtualbox-iso: Deleting output directory...
  Build 'virtualbox-iso' errored: Script exited with non-zero exit status: 1

  ==> Some builds didn't complete successfully and had errors:
  --> virtualbox-iso: Script exited with non-zero exit status: 1

  ==> Builds finished but no artifacts were created.
  make: **\* [box/virtualbox/centos71-desktop-nocm-2.0.4.box] Error 1
