### PR TITLE
Add Ansible Provisioner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Possible values for CM: (nocm | chef | chefdk | salt | puppet)
+# Possible values for CM: (nocm | ansible | chef | chefdk | salt | puppet)
 CM ?= nocm
 # Possible values for CM_VERSION: (latest | x.y.z | x.y)
 CM_VERSION ?=

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ the output of `make list` accordingly.
 Possible values for the CM variable are:
 
 * `nocm` - No configuration management tool
+* `ansible` - Install Ansible
 * `chef` - Install Chef
 * `chefdk` - Install Chef Development Kit
 * `puppet` - Install Puppet

--- a/script/cmtool.sh
+++ b/script/cmtool.sh
@@ -22,6 +22,19 @@ CM_VERSION=${CM_VERSION:-latest}
 # CM installs.
 #
 
+install_ansible()
+{
+    echo "==> Installing Ansible"
+    yum -y install epel-release libselinux-python
+    if [[ ${CM_VERSION:-} == 'latest' ]]; then
+        echo "==> Installing latest Ansible version"
+        yum -y install ansible
+    else
+        echo "==> Installing Ansible version ${CM_VERSION}"
+        yum -y install ansible-${CM_VERSION}
+    fi
+}
+
 install_chef()
 {
     echo "==> Installing Chef"
@@ -83,6 +96,10 @@ install_puppet()
 #
 
 case "${CM}" in
+  'ansible')
+    install_ansible
+    ;;
+
   'chef')
     install_chef
     ;;


### PR DESCRIPTION
Hi,

Here's a simple PR to add ansible provisioner.
I've tested this with CentOS 6.7 but I can't guarantee it will work with CentOS 5

It relies on ansible being in the EPEL repo and that the epel-release package is accessible directly from CentOS repos.
