### PR TITLE
CentOS 6.7 listed twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains Packer templates for creating CentOS Vagrant boxes.
 * [CentOS 6.7 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos67)
 * [CentOS 6.7 Desktop (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos67-desktop)
 * [CentOS 6.7 with Docker (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos67-docker/)
-* [CentOS 6.7 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos67)
+* [CentOS 6.6 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos66)
 * [CentOS 6.6 Desktop (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos66-desktop)
 * [CentOS 6.6 with Docker (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos66-docker/)
 * [CentOS 6.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/centos65/)


### PR DESCRIPTION
Fix a small typo where the CentOS 6.7 (64-bit) box was listed twice. Based on the ordering of the other boxes, the listing should be for the CentOS 6.6 (64-bit) box.
