### PR TITLE
Removed lines duplicated from virtualbox.sh causing unwanted removal of user installed software

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -69,9 +69,6 @@ if [ $(ls | wc -w) -gt 16 ]; then
 fi
 popd
 
-echo "==> Remove packages needed for building guest tools"
-yum -y remove gcc cpp libmpc mpfr kernel-devel kernel-headers perl
-
 echo "==> Clean up yum cache of metadata and packages to save space"
 yum -y --enablerepo='*' clean all
 


### PR DESCRIPTION
These lines are actually part of script/vmware.sh and script/virtualbox.sh. In cleanup.sh they actually delete too much, in case somebody installed other software depending on them, such as additional Perl modules. This software will then be removed as well. They are also not present in the ubuntu boxcutter repository.
