### PR TITLE
Fixed typo in comment for 7.3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Ross Smith II <ross@smithii.com>
 Ryan Lee <ryan@ryanl.ee>
 Trevor Dearham <Trevor.Dearham@gmail.com>
 Victor Volle <v.volle@computer.org>
+Drew Budwin <dbudwin@foxguardsolutions.com>

--- a/centos73-desktop.json
+++ b/centos73-desktop.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Build with `packer build -var-file=centos72-desktop.json centos.json`",
+  "_comment": "Build with `packer build -var-file=centos73-desktop.json centos.json`",
   "vm_name": "centos73-desktop",
   "cpus": "1",
   "desktop": "true",

--- a/centos73.json
+++ b/centos73.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Build with `packer build -var-file=centos72.json centos.json`",
+  "_comment": "Build with `packer build -var-file=centos73.json centos.json`",
   "vm_name": "centos73",
   "cpus": "1",
   "disk_size": "65536",


### PR DESCRIPTION
The comment in CentOS 7.3 JSON files referred to the previous version, 7.2.