### PR TITLE
Use Minimal ISO?

### DIFF
--- a/centos7.json
+++ b/centos7.json
@@ -4,10 +4,10 @@
   "cpus": "1",
   "disk_size": "65536",
   "http_directory": "kickstart/centos7",
-  "iso_checksum": "506e4e06abf778c3435b4e5745df13e79ebfc86565d7ea1e128067ef6b5a6345",
+  "iso_checksum": "714acc0aefb32b7d51b515e25546835e55a90da9fb00417fbee2d03a62801efd",
   "iso_checksum_type": "sha256",
-  "iso_name": "CentOS-7-x86_64-DVD-1804.iso",
-  "iso_url": "http://mirrors.sonic.net/centos/7.5.1804/isos/x86_64/CentOS-7-x86_64-DVD-1804.iso",
+  "iso_name": "CentOS-7-x86_64-Minimal-1804.iso",
+  "iso_url": "http://mirrors.sonic.net/centos/7.5.1804/isos/x86_64/CentOS-7-x86_64-Minimal-1804.iso",
   "memory": "512",
   "parallels_guest_os_type": "centos7"
 }


### PR DESCRIPTION
I guess I can understand that you don't want both ISOs, but we do not have a need for a desktop vagrant box, and do not want to download the entire DVD for a minimal system. Just a thought?

~tommy