### PR TITLE
add centos 8 support with minimal changes

### DIFF
--- a/centos8-desktop.json
+++ b/centos8-desktop.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Build with `packer build -var-file=centos8-desktop.json centos.json`",
+  "vm_name": "centos8-desktop",
+  "cpus": "1",
+  "desktop": "true",
+  "disk_size": "130048",
+  "http_directory": "kickstart/centos8-desktop",
+  "iso_checksum": "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
+  "iso_checksum_type": "sha256",
+  "iso_name": "CentOS-8.3.2011-x86_64-dvd1.iso",
+  "iso_url": "https://mirrors.edge.kernel.org/centos/8.3.2011/isos/x86_64/CentOS-8.3.2011-x86_64-dvd1.iso",
+  "memory": "1024",
+  "paralles_guest_os_type": "centos8",
+  "vagrantfile_template": "tpl/vagrantfile-centos8-desktop.tpl"
+}

--- a/centos8.json
+++ b/centos8.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Build with `packer build -var-file=centos8.json centos.json`",
+  "vm_name": "centos8",
+  "cpus": "1",
+  "disk_size": "65536",
+  "http_directory": "kickstart/centos8",
+  "iso_checksum": "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
+  "iso_checksum_type": "sha256",
+  "iso_name": "CentOS-8.3.2011-x86_64-dvd1.iso",
+  "iso_url": "https://mirrors.edge.kernel.org/centos/8.3.2011/isos/x86_64/CentOS-8.3.2011-x86_64-dvd1.iso",
+  "memory": "1024",
+  "parallels_guest_os_type": "centos8"
+}

--- a/kickstart/centos8-desktop/ks.cfg
+++ b/kickstart/centos8-desktop/ks.cfg
@@ -1,0 +1,89 @@
+# CentOS 7.x kickstart file - ks7.cfg
+#
+# For more information on kickstart syntax and commands, refer to the
+# CentOS Installation Guide:
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
+#
+# For testing, you can fire up a local http server temporarily.
+# cd to the directory where this ks.cfg file resides and run the following:
+#    $ python -m SimpleHTTPServer
+# You don't have to restart the server every time you make changes.  Python
+# will reload the file from disk every time.  As long as you save your changes
+# they will be reflected in the next HTTP download.  Then to test with
+# a PXE boot server, enter the following on the PXE boot prompt:
+#    > linux text ks=http://<your_ip>:8000/ks.cfg
+
+# Required settings
+lang en_US.UTF-8
+keyboard us
+rootpw vagrant
+authconfig --enableshadow --enablemd5
+timezone UTC
+
+# Optional settings
+install
+cdrom
+user --name=vagrant --plaintext --password vagrant
+network --device eth0 --bootproto=dhcp
+network --bootproto=dhcp
+firewall --disabled
+selinux --permissive
+# The biosdevname and ifnames options ensure we get "eth0" as our interface
+# even in environments like virtualbox that emulate a real NW card
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+text
+xconfig  --startxonboot --defaultdesktop=gnome
+eula --agreed
+zerombr
+clearpart --all --initlabel
+autopart
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing --excludedocs
+@core
+@fonts
+@x11
+@gnome-desktop
+@input-methods
+anaconda
+isomd5sum
+kernel
+memtest86+
+grub2-efi
+grub2
+shim
+syslinux
+-dracut-config-rescue
+# vagrant needs this to copy initial files via scp
+openssh-clients
+# Prerequisites for installing VMware Tools or VirtualBox guest additions.
+# Put in kickstart to ensure first version installed is from install disk,
+# not latest from a mirror.
+kernel-headers
+kernel-devel
+gcc
+make
+perl
+curl
+wget
+bzip2
+dkms
+patch
+net-tools
+git
+# Core selinux dependencies installed on 7.x, no need to specify
+# Other stuff
+sudo
+nfs-utils
+%end
+
+%post
+# configure vagrant user in sudoers
+echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+cp /etc/sudoers /etc/sudoers.orig
+sed -i "s/^\(.*requiretty\)$/#\1/" /etc/sudoers
+# keep proxy settings through sudo
+echo 'Defaults env_keep += "HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY NO_PROXY"' >> /etc/sudoers
+%end

--- a/kickstart/centos8/ks.cfg
+++ b/kickstart/centos8/ks.cfg
@@ -1,0 +1,99 @@
+# CentOS 7.x kickstart file - centos7.ks
+#
+# For more information on kickstart syntax and commands, refer to the
+# CentOS Installation Guide:
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
+#
+# For testing, you can fire up a local http server temporarily.
+# cd to the directory where this ks.cfg file resides and run the following:
+#    $ python -m SimpleHTTPServer
+# You don't have to restart the server every time you make changes.  Python
+# will reload the file from disk every time.  As long as you save your changes
+# they will be reflected in the next HTTP download.  Then to test with
+# a PXE boot server, enter the following on the PXE boot prompt:
+#    > linux text ks=http://<your_ip>:8000/ks.cfg
+
+# Required settings
+lang en_US.UTF-8
+keyboard us
+rootpw vagrant
+authconfig --enableshadow --enablemd5
+timezone UTC
+
+# Optional settings
+install
+cdrom
+user --name=vagrant --plaintext --password vagrant
+# unsupported_hardware
+network --device eth0 --bootproto=dhcp
+firewall --disabled
+selinux --permissive
+# The biosdevname and ifnames options ensure we get "eth0" as our interface
+# even in environments like virtualbox that emulate a real NW card
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+firstboot --disabled
+reboot
+
+%packages --ignoremissing --excludedocs
+# vagrant needs this to copy initial files via scp
+openssh-clients
+# Prerequisites for installing VMware Tools or VirtualBox guest additions.
+# Put in kickstart to ensure first version installed is from install disk,
+# not latest from a mirror.
+kernel-headers
+kernel-devel
+gcc
+make
+perl
+curl
+wget
+bzip2
+dkms
+patch
+net-tools
+selinux-policy-devel
+# Core selinux dependencies installed on 7.x, no need to specify
+# Other stuff
+sudo
+nfs-utils
+-fprintd-pam
+-intltool
+
+# Microcode updates cannot work in a VM
+-microcode_ctl
+# unnecessary firmware
+-aic94xx-firmware
+-alsa-firmware
+-alsa-tools-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw*-firmware
+-irqbalance
+-ivtv-firmware
+-iwl*-firmware
+-kernel-firmware
+-libertas-usb8388-firmware
+-ql*-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+# Don't build rescue initramfs
+-dracut-config-rescue
+%end
+
+%post
+# configure vagrant user in sudoers
+echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+cp /etc/sudoers /etc/sudoers.orig
+sed -i "s/^\(.*requiretty\)$/#\1/" /etc/sudoers
+# keep proxy settings through sudo
+echo 'Defaults env_keep += "HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY NO_PROXY"' >> /etc/sudoers
+%end

--- a/script/vmware.sh
+++ b/script/vmware.sh
@@ -8,7 +8,7 @@ function install_open_vm_tools {
     # Install open-vm-tools so we can mount shared folders
     yum install -y open-vm-tools
     # Add /mnt/hgfs so the mount works automatically with Vagrant
-    mkdir /mnt/hgfs
+    mkdir -p /mnt/hgfs
 }
 
 function install_vmware_tools {

--- a/tpl/vagrantfile-centos8-desktop.tpl
+++ b/tpl/vagrantfile-centos8-desktop.tpl
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+   config.vm.define "vagrant-centos8-desktop"
+   config.vm.box = "centos8-desktop"
+
+   config.vm.provider :virtualbox do |v, override|
+     v.gui = true
+     v.customize ["modifyvm", :id, "--memory", 1024]
+     v.customize ["modifyvm", :id, "--cpus", 1]
+     v.customize ["modifyvm", :id, "--vram", "256"]
+     v.customize ["setextradata", "global", "GUI/MaxGuestResolution", "any"]
+     v.customize ["setextradata", :id, "CustomVideoMode1", "1024x768x32"]
+     v.customize ["modifyvm", :id, "--ioapic", "on"]
+     v.customize ["modifyvm", :id, "--rtcuseutc", "on"]
+     v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+     v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+   end
+
+  ["vmware_fusion", "vmware_workstation"].each do |provider|
+    config.vm.provider provider do |v, override|
+      v.gui = true
+      v.vmx["memsize"] = "1024"
+      v.vmx["numvcpus"] = "1"
+      v.vmx["cpuid.coresPerSocket"] = "1"
+      v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+      v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+      v.vmx["RemoteDisplay.vnc.port"] = "5900"
+      v.vmx["scsi0.virtualDev"] = "lsilogic"
+      v.vmx["mks.enable3d"] = "TRUE"
+    end
+  end
+end


### PR DESCRIPTION
Centos 8 release pattern is superseded by [Centos Stream](https://blog.centos.org/2020/12/future-is-centos-stream/) however having a box base on the last official release that is supported until December 2021 still has value.

This is similar to #86 however, at least in my local testing, Centos 8 required 1024M in ram to load the install env properly.  This PR also focuses on only adding Centos 8 and makes no other changes.

The update to `vmware.sh` is to allow for scenarios where `/mnt/hgfs` already exists in the VM.

closes #88